### PR TITLE
plot_scree for h5py>=3

### DIFF
--- a/sidpy/viz/plot_utils/curve.py
+++ b/sidpy/viz/plot_utils/curve.py
@@ -515,6 +515,8 @@ def plot_scree(scree, title='Scree', **kwargs):
         raise TypeError('scree must be a 1D array or Dataset')
     if not isinstance(title, (str, unicode)):
         raise TypeError('title must be a string')
+    if h5py.__version__ >= '3' and isinstance(scree, h5py.Dataset):
+        scree = scree[()]
 
     fig = plt.figure(figsize=kwargs.pop('figsize', (6.5, 6)))
     axis = fig.add_axes([0.1, 0.1, .8, .8])  # left, bottom, width, height (range 0 to 1)

--- a/tests/viz/test_plot_utils.py
+++ b/tests/viz/test_plot_utils.py
@@ -16,7 +16,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 sys.path.append("../../sidpy/")
 from sidpy.viz import plot_utils
-
+import h5py
 
 """
 class TestGridDecoration(unittest.TestCase):
@@ -502,6 +502,11 @@ class TestPlotScree(unittest.TestCase):
         scree = 'string'
         with self.assertRaises(TypeError):
             plot_utils.plot_scree(scree)
+
+    def test_scree_h5py_dataset(self):
+        h5_f = h5py.File('test.h5', 'a')
+        scree = h5_f.create_dataset("test", data=np.arange(1,25))
+        plot_utils.plot_scree(scree)
 
     """
     def test_scree_list(self):


### PR DESCRIPTION
Addresses Issue #105 which is part of a slightly larger issue (potentially) of h5py >=3 being more strict in handling Datasets, I think.

Wasn't sure of the best way to write the test, since I just want to see if it passes when using an h5py Dataset.