### PR TITLE
Fix for NaN values in plot_map and in get_exponent

### DIFF
--- a/sidpy/base/num_utils.py
+++ b/sidpy/base/num_utils.py
@@ -199,11 +199,14 @@ def get_exponent(vector):
     """
     if not isinstance(vector, np.ndarray):
         raise TypeError('vector should be of type numpy.ndarray. Provided object of type: {}'.format(type(vector)))
+    if np.isnan(vector).any():
+        raise TypeError('vector should not contain NaN values')
     if np.max(np.abs(vector)) == np.max(vector):
         exponent = np.log10(np.max(vector))
     else:
         # negative values
         exponent = np.log10(np.max(np.abs(vector)))
+        
     return int(np.floor(exponent))
 
 def build_ind_val_matrices(unit_values):

--- a/sidpy/viz/plot_utils/image.py
+++ b/sidpy/viz/plot_utils/image.py
@@ -107,7 +107,12 @@ def plot_map(axis, img, show_xy_ticks=True, show_cbar=True, x_vec=None, y_vec=No
     kwargs.update({'origin': kwargs.pop('origin', 'lower')})
 
     if show_cbar:
-        y_exp = get_exponent(np.squeeze(img))
+        
+        if np.isnan(img).any():
+            _img = img[np.where(~np.isnan(img))]
+            y_exp = get_exponent(np.squeeze(_img))
+        else:
+            y_exp = get_exponent(np.squeeze(img))
         z_suffix = ''
         if y_exp < -2 or y_exp > 3:
             img = np.squeeze(img) / 10 ** y_exp

--- a/tests/base/test_num_utils.py
+++ b/tests/base/test_num_utils.py
@@ -145,6 +145,7 @@ class TestGetExponent(unittest.TestCase):
         with self.assertRaises(TypeError):
             _ = get_exponent('hello')
             _ = get_exponent([1, 2, 3])
+            _ = get_exponent([0, 1, np.nan])
                 
 class TestBuildIndValMatrices(unittest.TestCase):
     '''Testing the build_ind_val_matrices function'''

--- a/tests/viz/test_plot_utils.py
+++ b/tests/viz/test_plot_utils.py
@@ -382,8 +382,6 @@ class TestPlotLineFamily(unittest.TestCase):
 
 class TestPlotMap(unittest.TestCase):
 
-    pass
-    """
     def test_plot_map(self):
         x_vec = np.linspace(0, 6 * np.pi, 256)
         y_vec = np.sin(x_vec) ** 2
@@ -396,7 +394,20 @@ class TestPlotMap(unittest.TestCase):
                             y_vec=np.linspace(0, 500, atom_intensities.shape[1]),
                             cbar_label='intensity (a. u.)', tick_font_size=16)
     
-    """
+    def test_plot_map_with_nan(self):
+        
+        x_vec = np.linspace(0, 6 * np.pi, 256)
+        y_vec = np.sin(x_vec) ** 2
+    
+        atom_intensities = y_vec * np.atleast_2d(y_vec).T
+        rand_nan = np.where(np.random.rand(256,256) < 0.2)
+        atom_intensities[rand_nan] = np.nan
+    
+        fig, axis = plt.subplots()
+        plot_utils.plot_map(axis, atom_intensities, stdevs=1.5, num_ticks=4,
+                            x_vec=np.linspace(-1, 1, atom_intensities.shape[0]),
+                            y_vec=np.linspace(0, 500, atom_intensities.shape[1]),
+                            cbar_label='intensity (a. u.)', tick_font_size=16)
 
 
 class TestPlotCurves(unittest.TestCase):


### PR DESCRIPTION
For issue #124 . Get_exponent returns TypeError now with informative error message if vector contains nan values. Plot_map ignores nan values when calling get_exponent. Tests added for both