### PR TITLE
tick.label to tick.label1 for mpl deprctn

### DIFF
--- a/sidpy/viz/plot_utils/misc.py
+++ b/sidpy/viz/plot_utils/misc.py
@@ -74,9 +74,9 @@ def set_tick_font_size(axes, font_size):
             axis to set font sizes
         """
         for tick in axis.xaxis.get_major_ticks():
-            tick.label.set_fontsize(font_size)
+            tick.label1.set_fontsize(font_size)
         for tick in axis.yaxis.get_major_ticks():
-            tick.label.set_fontsize(font_size)
+            tick.label1.set_fontsize(font_size)
 
     mesg = 'axes must either be a matplotlib.axes.Axes object or an iterable containing such objects'
 


### PR DESCRIPTION
matplotlib is depreciating tick.label. It is now tick.label1 . 